### PR TITLE
Audit code : rapport CSV, nettoyage dead code, champs inutilisés

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -719,6 +719,24 @@ body::before {
 /* Style ligne prédicteur OTP/OTD */
 .predictor-order { font-size: 11px; color: var(--muted); margin-top: 2px; }
 
+/* ── Bandeau rapport de parsing ── */
+.parse-report {
+  display: flex; align-items: center; gap: 10px;
+  background: rgba(201,168,76,.08); border: 1px solid rgba(201,168,76,.25);
+  border-radius: 10px; padding: 8px 14px; margin-bottom: 16px;
+  font-size: 13px; color: var(--muted); font-family: 'Crimson Pro', serif;
+}
+.parse-report-icon {
+  flex-shrink: 0; font-size: 15px; color: var(--gold); line-height: 1;
+}
+.parse-report-text { flex: 1; }
+.parse-report-close {
+  flex-shrink: 0; background: none; border: none; color: var(--muted);
+  cursor: pointer; font-size: 14px; padding: 2px 6px; border-radius: 6px;
+  transition: color .15s ease;
+}
+.parse-report-close:hover { color: var(--text); }
+
 /* ═══════════════════════════════════════════════════════════════
    PAGE DECKS
    ═══════════════════════════════════════════════════════════════ */

--- a/index.html
+++ b/index.html
@@ -152,6 +152,13 @@
         </span>
       </div>
 
+      <!-- RAPPORT DE PARSING (lignes ignorées à l'import) -->
+      <div id="parseReport" class="parse-report" style="display:none" role="status" aria-live="polite">
+        <span class="parse-report-icon" aria-hidden="true">ℹ</span>
+        <span id="parseReportText" class="parse-report-text"></span>
+        <button class="parse-report-close" id="parseReportClose" title="Fermer" aria-label="Fermer le rapport">✕</button>
+      </div>
+
       <!-- KPIs -->
       <div class="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-4 mb-6">
         <div class="kpi" style="--kpi-color:var(--gold-light)">

--- a/js/advanced/weekly.js
+++ b/js/advanced/weekly.js
@@ -1,9 +1,7 @@
 /**
- * advanced/weekly.js — Comparaison hebdomadaire & meilleur/pire deck (SRP)
- * getISOWeek, weekStats et renderBestWorstDeck sont des fonctions pures.
+ * advanced/weekly.js — Comparaison hebdomadaire (SRP)
+ * getISOWeek et weekStats sont des fonctions pures.
  */
-
-import { esc } from '../utils/html.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -83,47 +81,3 @@ export function renderWeekComparison(allGames) {
     </div>`;
 }
 
-// ── Meilleur / Pire deck (20 dernières parties) ────────────────────────────
-
-export function renderBestWorstDeck(allGames) {
-  const last20 = allGames.slice(-20);
-  const byDeck = {};
-  for (const g of last20) {
-    (byDeck[g.myColors] = byDeck[g.myColors] || []).push(g);
-  }
-
-  const stats = Object.entries(byDeck)
-    .map(([deck, gs]) => {
-      const wins   = gs.filter(g => g.result === 'Win').length;
-      const losses = gs.filter(g => g.result === 'Loss').length;
-      return { deck, total: gs.length, wins, losses, rate: wins / gs.length * 100 };
-    })
-    .filter(s => s.total >= 2)
-    .sort((a, b) => b.rate - a.rate);
-
-  const container = document.getElementById('bestWorstContent');
-  if (!stats.length) {
-    container.innerHTML = '<p class="empty-msg">Pas assez de données.</p>';
-    return;
-  }
-
-  container.innerHTML = stats.map((s, i) => {
-    const isFirst = i === 0;
-    const isLast  = i === stats.length - 1 && stats.length > 1;
-    const medal   = isFirst ? '🥇' : isLast ? '💀' : `#${i + 1}`;
-    const color   = s.rate >= 60 ? 'var(--win)' : s.rate >= 40 ? 'var(--gold-light)' : 'var(--loss)';
-    const bg      = isFirst ? 'rgba(78,204,163,.08)' : isLast ? 'rgba(232,93,122,.08)' : 'transparent';
-    const border  = isFirst ? 'rgba(78,204,163,.3)'  : isLast ? 'rgba(232,93,122,.3)'  : 'var(--border)';
-
-    return `
-      <div class="bw-row" style="background:${bg};border-color:${border}">
-        <span class="bw-medal">${medal}</span>
-        <span class="bw-deck">${esc(s.deck)}</span>
-        <div class="bw-bar-wrap">
-          <div class="bw-bar" style="width:${s.rate.toFixed(0)}%;background:${color}"></div>
-        </div>
-        <span class="bw-rate"   style="color:${color}">${s.rate.toFixed(0)}%</span>
-        <span class="bw-record">${s.wins}V/${s.losses}D</span>
-      </div>`;
-  }).join('');
-}

--- a/js/app.js
+++ b/js/app.js
@@ -94,12 +94,45 @@ function onRerender() {
   renderMomentumSection();
 }
 
+// ── Rapport de parsing (lignes ignorées + avertissements) ──────────────────
+
+function showParseReport(ignored, warnings) {
+  const el = document.getElementById('parseReport');
+  if (!el) return;
+
+  const total = ignored.invalidResult + ignored.missingColors + ignored.duplicates;
+
+  if (!total && !warnings.length) {
+    el.style.display = 'none';
+    return;
+  }
+
+  const parts = [];
+  if (ignored.invalidResult > 0)
+    parts.push(`${ignored.invalidResult} résultat${ignored.invalidResult > 1 ? 's' : ''} invalide${ignored.invalidResult > 1 ? 's' : ''}`);
+  if (ignored.missingColors > 0)
+    parts.push(`${ignored.missingColors} couleur${ignored.missingColors > 1 ? 's' : ''} manquante${ignored.missingColors > 1 ? 's' : ''}`);
+  if (ignored.duplicates > 0)
+    parts.push(`${ignored.duplicates} doublon${ignored.duplicates > 1 ? 's' : ''}`);
+
+  const segments = [];
+  if (total > 0)
+    segments.push(`${total} ligne${total > 1 ? 's' : ''} ignorée${total > 1 ? 's' : ''} à l'import (${parts.join(', ')})`);
+  if (warnings.length)
+    segments.push(...warnings);
+
+  document.getElementById('parseReportText').textContent = segments.join(' · ');
+  el.style.display = 'flex';
+
+  document.getElementById('parseReportClose').onclick = () => { el.style.display = 'none'; };
+}
+
 // ── Callbacks ──────────────────────────────────────────────────────────────
 
 function onCSV(csvText) {
   try {
-    // B4 : parseCSV retourne { games, warnings }
-    const { games, warnings } = parseCSV(csvText);
+    // B4 : parseCSV retourne { games, warnings, ignored }
+    const { games, warnings, ignored } = parseCSV(csvText);
     store.setGames(games);
     showDashboard();
 
@@ -130,8 +163,8 @@ function onCSV(csvText) {
     renderMMRSection();         // rendu initial MMR
     renderMomentumSection();    // rendu initial Momentum
 
-    // B4 : affichage des avertissements de parsing (non bloquants)
-    if (warnings.length) showUploadError(warnings.join(' · '));
+    // Rapport de parsing : lignes ignorées + avertissements (dans le dashboard)
+    showParseReport(ignored, warnings);
   } catch (err) {
     showUploadScreen();
     showUploadError(err.message);

--- a/js/charts/distribution.js
+++ b/js/charts/distribution.js
@@ -1,11 +1,9 @@
 /**
  * distribution.js — Graphiques de distribution (SRP)
- * Win/Loss donut, parties par jour, barres winrate deck.
+ * Win/Loss donut, parties par jour.
  */
 
-import { destroyChart, registerChart, groupBy, winStats, avg, GRID } from './registry.js';
-import { inkBadge } from '../utils/ink.js';
-import { esc }      from '../utils/html.js';
+import { destroyChart, registerChart, groupBy, avg, GRID } from './registry.js';
 
 // ── Win/Loss Donut ─────────────────────────────────────────────────────────
 
@@ -107,25 +105,3 @@ export function renderDailyChart(games) {
   }));
 }
 
-// ── Barres winrate par deck (HTML) ─────────────────────────────────────────
-
-export function renderDeckBars(games, colorKey, containerId, minGames = 1) {
-  const stats = Object.entries(groupBy(games, colorKey))
-    .map(([k, gs]) => ({ deck: k, ...winStats(gs) }))
-    .filter(s => s.total >= minGames)
-    .sort((a, b) => b.total - a.total);
-
-  document.getElementById(containerId).innerHTML = stats.map(s => {
-    const color = s.rate >= 50 ? '#4ecca3' : '#e85d7a';
-    return `
-      <div class="bar-row">
-        <div class="bar-label" title="${esc(s.deck)}">${inkBadge(s.deck, 18)}</div>
-        <div class="bar-track">
-          <div class="bar-fill" style="width:${s.rate.toFixed(1)}%;background:${color}"></div>
-        </div>
-        <div class="bar-stat">
-          ${s.rate.toFixed(0)}%<span class="bar-count">(${s.total})</span>
-        </div>
-      </div>`;
-  }).join('');
-}

--- a/js/parser.js
+++ b/js/parser.js
@@ -66,6 +66,9 @@ export function parseCSV(csvText) {
   // B1 : déduplication — clé composite startedAt + opponent + result
   const seen = new Set();
 
+  // Compteurs de lignes ignorées par raison
+  const ignored = { invalidResult: 0, missingColors: 0, duplicates: 0 };
+
   const games = parsed.data.map(row => {
     const startedAt = (row['Started At'] || '').trim();
     const dt        = startedAt ? new Date(startedAt) : null;
@@ -76,34 +79,33 @@ export function parseCSV(csvText) {
     if (rawDecklist && !decklist.length) decklisFailCount++;
 
     return {
-      date:        (row['Date']           || '').trim(),
+      date:      (row['Date']           || '').trim(),
       startedAt,
       dt,
-      // B3 : heure et jour en temps local (plus getUTCHours/getUTCDay)
-      dayOfWeek:   dt ? ((dt.getDay() + 6) % 7) : null, // 0=Lun … 6=Dim
-      hour:        dt ? dt.getHours()             : null,
-      result:      (row['Result']         || '').trim(),
-      opponent:    (row['Opponent']       || '').trim(),
+      result:    (row['Result']         || '').trim(),
+      opponent:  (row['Opponent']       || '').trim(),
       // Q2 : validation des valeurs numériques
-      myLore:      clamp(parseInt(row['My Lore'])       || 0, 0, 20),
-      oppLore:     clamp(parseInt(row['Opponent Lore']) || 0, 0, 20),
-      turns:       Math.max(0, parseInt(row['Turns'])   || 0),
-      duration:    Math.max(0, parseDuration(row['Duration'] || '')),
-      turnOrder:   (row['Turn Order']     || '').trim(),
-      myColors:    (row['My Colors']      || '').trim(),
-      oppColors:   (row['Opponent Colors']|| '').trim(),
-      mmrBefore:   parseMMR(row['MMR Before']),
-      mmrAfter:    parseMMR(row['MMR After']),
-      matchFormat: (row['Match Format']   || '').trim(),
+      myLore:    clamp(parseInt(row['My Lore'])       || 0, 0, 20),
+      oppLore:   clamp(parseInt(row['Opponent Lore']) || 0, 0, 20),
+      turns:     Math.max(0, parseInt(row['Turns'])   || 0),
+      duration:  Math.max(0, parseDuration(row['Duration'] || '')),
+      turnOrder: (row['Turn Order']     || '').trim(),
+      myColors:  (row['My Colors']      || '').trim(),
+      oppColors: (row['Opponent Colors']|| '').trim(),
+      mmrBefore: parseMMR(row['MMR Before']),
+      mmrAfter:  parseMMR(row['MMR After']),
       // F5 : extraction de la file de jeu
-      queue:       (row['Queue']          || '').trim(),
+      queue:     (row['Queue']          || '').trim(),
       decklist,
     };
   }).filter(g => {
-    if ((g.result !== 'Win' && g.result !== 'Loss') || !g.myColors) return false;
+    // Résultat invalide
+    if (g.result !== 'Win' && g.result !== 'Loss') { ignored.invalidResult++; return false; }
+    // Couleurs manquantes
+    if (!g.myColors) { ignored.missingColors++; return false; }
     // B1 : élimination des doublons
     const key = `${g.startedAt}|${g.opponent}|${g.result}`;
-    if (seen.has(key)) return false;
+    if (seen.has(key)) { ignored.duplicates++; return false; }
     seen.add(key);
     return true;
   });
@@ -119,5 +121,5 @@ export function parseCSV(csvText) {
     );
   }
 
-  return { games, warnings };
+  return { games, warnings, ignored };
 }


### PR DESCRIPTION
- parser.js : tracker les lignes ignorées par raison (résultat invalide,
  couleurs manquantes, doublons) ; retourne { games, warnings, ignored }.
  Suppression des champs jamais lus : matchFormat, dayOfWeek, hour.
- app.js : fix bug — les warnings de parsing étaient affichés sur l'écran
  d'upload déjà masqué (jamais visibles). Ajout de showParseReport() qui
  affiche un bandeau dans le dashboard avec le détail des lignes ignorées
  et les avertissements de decklist.
- index.html + style.css : bandeau #parseReport dismissible sous la
  filter-bar, visible uniquement quand des lignes ont été ignorées.
- weekly.js : suppression de renderBestWorstDeck (dead code — conteneur
  #bestWorstContent absent du HTML, fonction jamais appelée). Suppression
  de l'import esc devenu orphelin.
- distribution.js : suppression de renderDeckBars (dead code — jamais
  appelée). Suppression des imports inkBadge, esc et winStats orphelins.

https://claude.ai/code/session_01ByuNnWFkmcKCnjdCAaEvTZ